### PR TITLE
Remove root test script referencing missing package command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "dev": "pnpm --filter number-line-adventure dev",
     "build": "pnpm --filter number-line-adventure build",
-    "lint": "pnpm --filter number-line-adventure lint",
-    "test": "pnpm --filter number-line-adventure test"
+    "lint": "pnpm --filter number-line-adventure lint"
   },
   "keywords": [
     "math",


### PR DESCRIPTION
## Summary
- remove the root `test` script that delegated to a non-existent package script so `pnpm test` no longer fails with “Missing script: test”

## Testing
- ⚠️ `pnpm lint` *(fails because Next.js dependencies are not installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69158c2538448321b2ac928b3bb0d98d)